### PR TITLE
Refactor/add sad paths to tests

### DIFF
--- a/src/classes/Recipe.js
+++ b/src/classes/Recipe.js
@@ -1,13 +1,13 @@
 class Recipe {
   constructor(recipeData) {
-    this.id = recipeData.id;
-    this.image = recipeData.image;
-    this.ingredients = recipeData.ingredients;
-    this.instructions = recipeData.instructions;
-    this.name = recipeData.name;
-    this.tags = recipeData.tags;
-    this.ingredientsList = [];
-    this.totalCost;
+    this.id = recipeData.id
+    this.image = recipeData.image
+    this.ingredients = recipeData.ingredients
+    this.instructions = recipeData.instructions
+    this.name = recipeData.name
+    this.tags = recipeData.tags
+    this.ingredientsList = []
+    this.totalCost
   }
   determineIngredients(ingredientInfo) {
     this.ingredientsList = ingredientInfo.reduce((acc, ingredient) => {

--- a/test/Ingredients-test.js
+++ b/test/Ingredients-test.js
@@ -11,11 +11,9 @@ describe('Ingredients', () => {
     sampleIngredientsData
     ingredients = new Ingredients(sampleIngredientsData)
   })
-
   it('Should be a function', () => {
     expect(Ingredients).to.be.a('function')
   })
-
   it('Should have a property of ingredients', () => {
     expect(ingredients.ingredients).to.deep.equal(sampleIngredientsData)
   })

--- a/test/Recipe-test.js
+++ b/test/Recipe-test.js
@@ -23,35 +23,35 @@ describe('Recipe', () => {
     expect(recipe1.id).to.equal(595736)
     expect(recipe2.id).to.equal(678353)
   })
-  it("should hold property of image", () => {
-    expect(recipe1.image).to.equal("https://spoonacular.com/recipeImages/595736-556x370.jpg")
-    expect(recipe2.image).to.equal("https://spoonacular.com/recipeImages/678353-556x370.jpg")
+  it('should hold property of image', () => {
+    expect(recipe1.image).to.equal('https://spoonacular.com/recipeImages/595736-556x370.jpg')
+    expect(recipe2.image).to.equal('https://spoonacular.com/recipeImages/678353-556x370.jpg')
   })
-  it("should hold property of ingredients", () => {
-    expect(recipe1.ingredients).to.deep.equal([{"id": 20081, "quantity": {"amount": 1.5, "unit": "c"}}, {"id": 18372, "quantity": {"amount": 0.5, "unit": "tsp"}}, {"id": 1123, "quantity": {"amount": 1, "unit": "large"}},{"id": 19335,"quantity": {"amount": 0.5,"unit": "c"}}])
-    expect(recipe2.ingredients).to.deep.equal([{"id": 1009016,"quantity": {"amount": 1.5,"unit": "cups"}},{"id": 20027,"quantity": {"amount": 1,"unit": "tablespoon"}},{"id": 1002046,"quantity": {"amount": 1,"unit": "tablespoon"}},{"id": 11215,"quantity": {"amount": 1,"unit": "clove"}}])
+  it('should hold property of ingredients', () => {
+    expect(recipe1.ingredients).to.deep.equal([{'id': 20081, 'quantity': {'amount': 1.5, 'unit': 'c'}}, {'id': 18372, 'quantity': {'amount': 0.5, 'unit': 'tsp'}}, {'id': 1123, 'quantity': {'amount': 1, 'unit': 'large'}},{'id': 19335,'quantity': {'amount': 0.5,'unit': 'c'}}])
+    expect(recipe2.ingredients).to.deep.equal([{'id': 1009016,'quantity': {'amount': 1.5,'unit': 'cups'}},{'id': 20027,'quantity': {'amount': 1,'unit': 'tablespoon'}},{'id': 1002046,'quantity': {'amount': 1,'unit': 'tablespoon'}},{'id': 11215,'quantity': {'amount': 1,'unit': 'clove'}}])
   })
-  it("should hold property of instructions", () => {
-    expect(recipe1.instructions).to.deep.equal([{"instruction": "In a large mixing bowl, whisk together the dry ingredients (flour, pudding mix, soda and salt). Set aside.In a large mixing bowl of a stand mixer, cream butter for 30 seconds. Gradually add granulated sugar and brown sugar and cream until light and fluffy.","number": 1}, {"instruction": "Add egg and vanilla and mix until combined.", "number": 2}])
-    expect(recipe2.instructions).to.deep.equal([{"instruction": "Season the pork chops with salt and pepper and grill or pan fry over medium high heat until cooked, about 3-5 minutes per side. (If grilling, baste the chops in the maple dijon apple cider sauce as you grill.)Meanwhile, mix the remaining ingredients except the apple slices, bring to a simmer and cook until the sauce thickens, about 2-5 minutes.Grill or saute the apple slices until just tender but still crisp.Toss the pork chops and apple slices in the maple dijon apple cider sauce and enjoy!","number": 1}])
+  it('should hold property of instructions', () => {
+    expect(recipe1.instructions).to.deep.equal([{'instruction': 'In a large mixing bowl, whisk together the dry ingredients (flour, pudding mix, soda and salt). Set aside.In a large mixing bowl of a stand mixer, cream butter for 30 seconds. Gradually add granulated sugar and brown sugar and cream until light and fluffy.','number': 1}, {'instruction': 'Add egg and vanilla and mix until combined.', 'number': 2}])
+    expect(recipe2.instructions).to.deep.equal([{'instruction': 'Season the pork chops with salt and pepper and grill or pan fry over medium high heat until cooked, about 3-5 minutes per side. (If grilling, baste the chops in the maple dijon apple cider sauce as you grill.)Meanwhile, mix the remaining ingredients except the apple slices, bring to a simmer and cook until the sauce thickens, about 2-5 minutes.Grill or saute the apple slices until just tender but still crisp.Toss the pork chops and apple slices in the maple dijon apple cider sauce and enjoy!','number': 1}])
   })
-  it("should hold property of name", () => {
-    expect(recipe1.name).to.equal("Loaded Chocolate Chip Pudding Cookie Cups")
-    expect(recipe2.name).to.equal("Maple Dijon Apple Cider Grilled Pork Chops")
+  it('should hold property of name', () => {
+    expect(recipe1.name).to.equal('Loaded Chocolate Chip Pudding Cookie Cups')
+    expect(recipe2.name).to.equal('Maple Dijon Apple Cider Grilled Pork Chops')
   })
-  it("should hold property of tags", () => {
-    expect(recipe1.tags).to.deep.equal(["antipasti","starter","snack","appetizer","antipasto","hor d'oeuvre"])
-    expect(recipe2.tags).to.deep.equal(["lunch","main course","main dish","dinner"])
+  it('should hold property of tags', () => {
+    expect(recipe1.tags).to.deep.equal(['antipasti','starter','snack','appetizer','antipasto','hor d\'oeuvre'])
+    expect(recipe2.tags).to.deep.equal(['lunch','main course','main dish','dinner'])
   })
-  it("should hold property of ingredient list", () => {
+  it('should hold property of ingredient list, which starts as an empty array', () => {
     expect(recipe1.ingredientsList).to.deep.equal([])
     expect(recipe2.ingredientsList).to.deep.equal([])
   })
-  it("determine the names of ingredients needed", () => {
-    expect(recipe1.determineIngredients(sampleIngredientsData)).to.deep.equal([{ingredient: "1.50 c wheat flour"}, {ingredient: "0.50 tsp bicarbonate of soda"}, {ingredient: "1.00 large eggs" }, {ingredient: "0.50 c sucrose"}])
-    expect(recipe2.determineIngredients(sampleIngredientsData)).to.deep.equal([{ingredient: "1.50 cups apple cider"}, {ingredient: "1.00 tablespoon corn starch"}, {ingredient: "1.00 tablespoon dijon style mustard"}, {ingredient: "1.00 clove whole garlic clove"}])
+  it('determine the names of ingredients needed', () => {
+    expect(recipe1.determineIngredients(sampleIngredientsData)).to.deep.equal([{ingredient: '1.50 c wheat flour'}, {ingredient: '0.50 tsp bicarbonate of soda'}, {ingredient: '1.00 large eggs' }, {ingredient: '0.50 c sucrose'}])
+    expect(recipe2.determineIngredients(sampleIngredientsData)).to.deep.equal([{ingredient: '1.50 cups apple cider'}, {ingredient: '1.00 tablespoon corn starch'}, {ingredient: '1.00 tablespoon dijon style mustard'}, {ingredient: '1.00 clove whole garlic clove'}])
   })
-  it("should hold property of total cost", () => {
+  it('should hold property of total cost', () => {
     expect(recipe1.totalCost).to.equal(undefined)
     expect(recipe2.totalCost).to.equal(undefined)
   })
@@ -60,9 +60,9 @@ describe('Recipe', () => {
     expect(recipe2.calculateCost(sampleIngredientsData)).to.equal(17.77)
   })
   it('should be able to return its instructions', () => {
-    expect(recipe1.getInstructions()).to.deep.equal(["1. In a large mixing bowl, whisk together the dry ingredients (flour, pudding mix, soda and salt). Set aside.In a large mixing bowl of a stand mixer, cream butter for 30 seconds. Gradually add granulated sugar and brown sugar and cream until light and fluffy.", "2. Add egg and vanilla and mix until combined."])
+    expect(recipe1.getInstructions()).to.deep.equal(['1. In a large mixing bowl, whisk together the dry ingredients (flour, pudding mix, soda and salt). Set aside.In a large mixing bowl of a stand mixer, cream butter for 30 seconds. Gradually add granulated sugar and brown sugar and cream until light and fluffy.', '2. Add egg and vanilla and mix until combined.'])
   })
   it('should be able to return different instructions', () => {
-    expect(recipe2.getInstructions()).to.deep.equal(["1. Season the pork chops with salt and pepper and grill or pan fry over medium high heat until cooked, about 3-5 minutes per side. (If grilling, baste the chops in the maple dijon apple cider sauce as you grill.)Meanwhile, mix the remaining ingredients except the apple slices, bring to a simmer and cook until the sauce thickens, about 2-5 minutes.Grill or saute the apple slices until just tender but still crisp.Toss the pork chops and apple slices in the maple dijon apple cider sauce and enjoy!"])
+    expect(recipe2.getInstructions()).to.deep.equal(['1. Season the pork chops with salt and pepper and grill or pan fry over medium high heat until cooked, about 3-5 minutes per side. (If grilling, baste the chops in the maple dijon apple cider sauce as you grill.)Meanwhile, mix the remaining ingredients except the apple slices, bring to a simmer and cook until the sauce thickens, about 2-5 minutes.Grill or saute the apple slices until just tender but still crisp.Toss the pork chops and apple slices in the maple dijon apple cider sauce and enjoy!'])
   })
 })

--- a/test/RecipeRepository-test.js
+++ b/test/RecipeRepository-test.js
@@ -43,4 +43,7 @@ describe('RecipeRepo', () => {
     expect(recipeRepository.filterName('calamari')).to.deep.equal([])
     expect(recipeRepository.filterName('hamburger')).to.deep.equal([])
   })
+  it('Should return all recipes if an empty string is passed in.', () => {
+    expect(recipeRepository.filterName('')).to.deep.equal([recipe1, recipe2])
+  })
 })

--- a/test/RecipeRepository-test.js
+++ b/test/RecipeRepository-test.js
@@ -28,11 +28,19 @@ describe('RecipeRepo', () => {
     expect(recipeRepository.createRecipes(sampleRecipeData)).to.deep.equal([recipe1, recipe2])
   })
   it('Should filter a list of recipes based on a tag.', () => {
-    expect(recipeRepository.filterTag("lunch")).to.deep.equal([recipe2])
-    expect(recipeRepository.filterTag("hor d'oeuvre")).to.deep.equal([recipe1])
+    expect(recipeRepository.filterTag('lunch')).to.deep.equal([recipe2])
+    expect(recipeRepository.filterTag('hor d\'oeuvre')).to.deep.equal([recipe1])
+  })
+  it('Should return an empty array if the tag passed in does not match any recipes.', () => {
+    expect(recipeRepository.filterTag('take-out')).to.deep.equal([])
+    expect(recipeRepository.filterTag('food')).to.deep.equal([])
   })
   it('Should filter list of recipes based on its name.', () => {
-    expect(recipeRepository.filterName("maple dijon apple cider grilled pork chops")).to.deep.equal([recipe2])
-    expect(recipeRepository.filterName("loaded chocolate chip pudding cookie cups")).to.deep.equal([recipe1])
+    expect(recipeRepository.filterName('maple dijon apple cider grilled pork chops')).to.deep.equal([recipe2])
+    expect(recipeRepository.filterName('loaded chocolate chip pudding cookie cups')).to.deep.equal([recipe1])
+  })
+  it('Should return an empty array if the name searched does not match any recipes.', () => {
+    expect(recipeRepository.filterName('calamari')).to.deep.equal([])
+    expect(recipeRepository.filterName('hamburger')).to.deep.equal([])
   })
 })

--- a/test/User-test.js
+++ b/test/User-test.js
@@ -9,7 +9,6 @@ describe('User', () => {
   sampleRecipeData
   let recipe1, recipe2, user1, user2
 
-
   beforeEach(() => {
     user1 = new User(sampleUsersData[0])
     user2 = new User(sampleUsersData[1])
@@ -21,10 +20,10 @@ describe('User', () => {
   })
 
   it('should take a name', () => {
-    expect(user1.name).to.equal("Saige O'Kon")
+    expect(user1.name).to.equal('Saige O\'Kon')
   })
   it('should take another name', () => {
-    expect(user2.name).to.equal("Ephraim Goyette")
+    expect(user2.name).to.equal('Ephraim Goyette')
   })
   it('should take an id', () => {
     expect(user1.id).to.equal(1)
@@ -33,7 +32,7 @@ describe('User', () => {
     expect(user2.id).to.equal(2)
   })
   it('should have a list of ingredients in pantry', () => {
-    expect(user1.pantry).to.deep.equal([{"ingredient": 11297,"amount": 4},{"ingredient": 1082047,"amount": 10},{"ingredient": 20081,"amount": 5},{"ingredient": 11215,"amount": 5},{"ingredient": 2047,"amount": 6},{"ingredient": 1123,"amount": 8},{"ingredient": 11282,"amount": 4},{"ingredient": 6172,"amount": 2},{"ingredient": 2044,"amount": 2},{"ingredient": 2050,"amount": 4},{"ingredient": 1032009,"amount": 3},{"ingredient": 5114,"amount": 3},{"ingredient": 1017,"amount": 2},{"ingredient": 18371,"amount": 7},{"ingredient": 1001,"amount": 6},{"ingredient": 99223,"amount": 2},{"ingredient": 1230,"amount": 2},{"ingredient": 9152,"amount": 4},{"ingredient": 10611282,"amount": 2},{"ingredient": 93607,"amount": 2},{"ingredient": 14106,"amount": 4},{"ingredient": 1077,"amount": 4},{"ingredient": 6150,"amount": 2},{"ingredient": 1124,"amount": 2},{"ingredient": 10011693,"amount": 4},{"ingredient": 1102047,"amount": 2},{"ingredient": 19206,"amount": 2},{"ingredient": 1145,"amount": 4},{"ingredient": 1002030,"amount": 4},{"ingredient": 12061,"amount": 2},{"ingredient": 19335,"amount": 4},{"ingredient": 15152,"amount": 3},{"ingredient": 9003,"amount": 2},{"ingredient": 18372,"amount": 3},{"ingredient": 2027,"amount": 2}])
+    expect(user1.pantry).to.deep.equal([{'ingredient': 11297,'amount': 4},{'ingredient': 1082047,'amount': 10},{'ingredient': 20081,'amount': 5},{'ingredient': 11215,'amount': 5},{'ingredient': 2047,'amount': 6},{'ingredient': 1123,'amount': 8},{'ingredient': 11282,'amount': 4},{'ingredient': 6172,'amount': 2},{'ingredient': 2044,'amount': 2},{'ingredient': 2050,'amount': 4},{'ingredient': 1032009,'amount': 3},{'ingredient': 5114,'amount': 3},{'ingredient': 1017,'amount': 2},{'ingredient': 18371,'amount': 7},{'ingredient': 1001,'amount': 6},{'ingredient': 99223,'amount': 2},{'ingredient': 1230,'amount': 2},{'ingredient': 9152,'amount': 4},{'ingredient': 10611282,'amount': 2},{'ingredient': 93607,'amount': 2},{'ingredient': 14106,'amount': 4},{'ingredient': 1077,'amount': 4},{'ingredient': 6150,'amount': 2},{'ingredient': 1124,'amount': 2},{'ingredient': 10011693,'amount': 4},{'ingredient': 1102047,'amount': 2},{'ingredient': 19206,'amount': 2},{'ingredient': 1145,'amount': 4},{'ingredient': 1002030,'amount': 4},{'ingredient': 12061,'amount': 2},{'ingredient': 19335,'amount': 4},{'ingredient': 15152,'amount': 3},{'ingredient': 9003,'amount': 2},{'ingredient': 18372,'amount': 3},{'ingredient': 2027,'amount': 2}])
   })
   it('should have a list of recipes to cook', () => {
     expect(user2.recipesToCook).to.deep.equal([])
@@ -56,23 +55,23 @@ describe('User', () => {
   it('should filter recipesToCook by tag', () => {
     user1.addRecipesToCook(recipe1)
     user1.addRecipesToCook(recipe2)
-    expect(user1.filterToCookByTag("hor d'oeuvre")).to.deep.equal([recipe1])
-    expect(user1.filterToCookByTag("main dish")).to.deep.equal([recipe2])
+    expect(user1.filterToCookByTag('hor d\'oeuvre')).to.deep.equal([recipe1])
+    expect(user1.filterToCookByTag('main dish')).to.deep.equal([recipe2])
   })
   it('should return nothing if item does not exist in recipesToCook', () => {
     user2.addRecipesToCook(recipe1)
     user2.addRecipesToCook(recipe2)
-    expect(user2.filterToCookByTag("breakfast")).to.deep.equal([])
+    expect(user2.filterToCookByTag('breakfast')).to.deep.equal([])
   })
   it('should filter recipesToCook by name', () => {
     user1.addRecipesToCook(recipe1)
     user1.addRecipesToCook(recipe2)
-    expect(user1.filterToCookByName("loaded chocolate chip pudding cookie cups")).to.deep.equal([recipe1])
-    expect(user1.filterToCookByName("maple dijon apple cider grilled pork chops")).to.deep.equal([recipe2])
+    expect(user1.filterToCookByName('loaded chocolate chip pudding cookie cups')).to.deep.equal([recipe1])
+    expect(user1.filterToCookByName('maple dijon apple cider grilled pork chops')).to.deep.equal([recipe2])
   })
   it('should return nothing if name does exist in recipesToCook', () => {
     user2.addRecipesToCook(recipe1)
     user2.addRecipesToCook(recipe2)
-    expect(user2.filterToCookByName("suuushhhhhhiiii")).to.deep.equal([])
+    expect(user2.filterToCookByName('suuushhhhhhiiii')).to.deep.equal([])
   })
 })


### PR DESCRIPTION
Summary of the work done:

Add sad paths to RecipeRepository for the filterTag and filterName methods
This branch includes:

I also changed the double quotes to single quotes
Added a test per Kiko's advice to check what happens  if an empty string is passed into the filter
Contributed to code:

Eleanor
Needs to review:

Kiko and Jenn
Additional notes about any issues/questions remaining around this code:

Can you double-check to make sure that all sad paths are tested?
