### PR TITLE
Feature/tabable focus v2

### DIFF
--- a/src/scripts.js
+++ b/src/scripts.js
@@ -57,6 +57,9 @@ const missingIngredientList = document.querySelector('#missing-ingredient-list')
 // ~~~~~~~~~~~~~~ Event Listeners ~~~~~~~~~~~~~~~~~~~~
 window.addEventListener('load', fetchData([usersURL, recipesURL, ingredientsURL]))
 allRecipes.addEventListener('click', displayRecipeDetailPage)
+/////////////////////////WIP
+allRecipes.addEventListener('keydown', focusClick)
+///////////////////////////
 homeButton.addEventListener('click', displayHomePage)
 favoritesView.addEventListener('click', displayRecipeDetailPage)
 resetButton.addEventListener('click', resetFilter)
@@ -338,7 +341,7 @@ function removeRecipeFromFavorites() {
 // ~~~~~~~~~~~~~~ Helper Functions ~~~~~~~~~~~~~~~~~~~~
 function displayRecipePreview(current, view) {
     view.innerHTML += `
-    <figure class = 'fullwrap' id='${current.id}'>
+    <figure class = 'fullwrap' id='${current.id}' tabindex="0">
     <img src='${current.image}' alt='${current.name}'>
     <figcaption class='fullcap'>
         ${current.name}
@@ -480,4 +483,11 @@ function removeIngredientsFromPantry() {
         return acc
     }, [])
     return items
+}
+
+function focusClick(event){
+    // console.log(typeof event.keyCode)
+    if(event.keyCode === 32){
+        console.log("you hit spacebar")
+    }
 }

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -56,12 +56,11 @@ const missingIngredientList = document.querySelector('#missing-ingredient-list')
 
 // ~~~~~~~~~~~~~~ Event Listeners ~~~~~~~~~~~~~~~~~~~~
 window.addEventListener('load', fetchData([usersURL, recipesURL, ingredientsURL]))
-allRecipes.addEventListener('click', displayRecipeDetailPage)
-/////////////////////////WIP
-allRecipes.addEventListener('keydown', focusClick)
-///////////////////////////
+allRecipes.addEventListener('click', findRecipeOnClick)
+allRecipes.addEventListener('keydown', findRecipeOnTab)
 homeButton.addEventListener('click', displayHomePage)
 favoritesView.addEventListener('click', displayRecipeDetailPage)
+favoritesView.addEventListener('keydown', findRecipeOnTab)
 resetButton.addEventListener('click', resetFilter)
 favoriteRecipeButton.addEventListener('click', addRecipeToFavorites)
 removeRecipeButton.addEventListener('click', removeRecipeFromFavorites)
@@ -156,9 +155,6 @@ function displayPantryPage() {
 function displayRecipeDetailPage(event) {
     recipeView = true
     navMessage.innerText = ''
-    foundRecipe = recipeRepository.recipes.find((current) => {
-        return current.id === findId(event)
-    })
     if (user.recipesToCook.length > 0 && user.recipesToCook.includes(foundRecipe)) {
         show([removeRecipeButton])
     }
@@ -200,6 +196,7 @@ function displayRecipeDetailPage(event) {
         show([ingredientsNeededToCook])
     }
 }
+
 
 function displayRecipeInstructions() {
     let instructionsArray = foundRecipe.getInstructions()
@@ -339,6 +336,23 @@ function removeRecipeFromFavorites() {
 }
 
 // ~~~~~~~~~~~~~~ Helper Functions ~~~~~~~~~~~~~~~~~~~~
+function findRecipeOnClick(event){
+    foundRecipe = recipeRepository.recipes.find((current) => {
+        return current.id === Number(event.target.parentElement.id)
+    })
+    displayRecipeDetailPage(event)
+}
+
+function findRecipeOnTab(event){
+    if(event.keyCode === 32 || event.keyCode === 13){
+        event.preventDefault();
+        foundRecipe = recipeRepository.recipes.find((current) => {
+            return current.id === Number(event.target.id)
+        })
+        displayRecipeDetailPage(event)
+    }
+}
+
 function displayRecipePreview(current, view) {
     view.innerHTML += `
     <figure class = 'fullwrap' id='${current.id}' tabindex="0">
@@ -352,12 +366,6 @@ function displayRecipePreview(current, view) {
 
 function displayWelcomeMessage(user) {
     userName.innerText = `Welcome, ${user}!`
-}
-
-
-function findId(event) {
-    let recipeId = Number(event.target.parentElement.id)
-    return recipeId
 }
 
 function resetView() {
@@ -483,11 +491,4 @@ function removeIngredientsFromPantry() {
         return acc
     }, [])
     return items
-}
-
-function focusClick(event){
-    // console.log(typeof event.keyCode)
-    if(event.keyCode === 32){
-        console.log("you hit spacebar")
-    }
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -132,6 +132,7 @@ li {
   flex-direction: column;
   align-items: center;
   font-size: 20px;
+  padding-bottom: 5vw;
 }
 
 .ingredient-info {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,6 +1,18 @@
 * {
   font-family: 'Roboto', sans-serif;
-  /* border: solid 1px green; */
+}
+
+button:focus, .search-field:focus, .food-category:focus, 
+.selectMenu:focus, .quantityInput:focus{
+  outline-width: 4px;
+  outline-style: solid;
+  outline-color: #3c40c6;
+}
+
+figure:focus{
+  outline-width: 10px;
+  outline-style: solid;
+  outline-color: #3c40c6;
 }
 
 button {


### PR DESCRIPTION
Summary of the work done:

- This incorporates an accessibility feature where the use can tab focus any interactive element (button, radio button, textbox, recipe, etc.) and 'click' it with with the 'space-bar' or 'enter' key on their keyboard
- Website is fully accessible with clicking and/or keyboard-only use 

This branch includes:

- Assigned all interactive elements (buttons, radio buttons, text field) with focus rule in CSS
- Designed focus ring to be bright blue thick border so people w/ color blindness with notice it
- Manually assigned non-interactive elements (recipe images w/ `class=fullwrap`) to become focusable with `tabindex="0"`
- Created helper functions to determine element id when clicked (`findRecipeOnClick()`) or focused on (`findRecipeOnTab()`) through a keyCode conditional
- Refactored displayRecipeDetailPage since element ID depends on user's input (click or tab)
- Disabled page jump scroll with `event.preventDefault()` when user presses 'spacebar'
- Adjusted CSS on `ingredient-section` element so button or total cost is not touching bottom of page

Contributed to code:

- Kiko (with Jen's assistance)

Needs to review:

- Laruen
- Eleanor

Additional notes about any issues/questions remaining around this code:

- Let me know if you notice anything that shouldn't happen

Indicate anything that still needs to be addressed

- When you focus on the radio button, it will only highlight the first one THEN you'll need to use the arrow keys to access the rest. According to MDN, when a focus ring hits a series of options (radio buttons, dropdown menu), the user will then switch over to arrow keys, which they already know about. Therefore it is not broken, it is doing it correctly
