### PR TITLE
Feature/disable enable search add buttons

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -145,10 +145,10 @@
             </form>
             <button type="button" class="addButton" id="add-button" disabled>Add to Pantry</button>
         </menu>
-        <div>
-          <span>*Required Field*</span>
-          <span>*Required Field*</span>
-        </div>
+        <label class="required-message">
+          <p class="message"><span>*</span>Required Field<span>*</span></p>
+          <p class="message"><span>*</span>Number Required<span>*</span></p>
+        </label>
       <section id="error-handling"></section>
         <section class="pantryItems">
           <section class="ingredientsPantry">

--- a/dist/index.html
+++ b/dist/index.html
@@ -143,7 +143,7 @@
             <form class="quantity">
               <input type="text" placeholder="quantity" class="quantityInput" id="quantity-input">
             </form>
-            <button type="button" class="addButton" id="add-button">Add to Pantry</button>
+            <button type="button" class="addButton" id="add-button" disabled>Add to Pantry</button>
         </menu>
         <div>
           <span>*Required Field*</span>

--- a/dist/index.html
+++ b/dist/index.html
@@ -141,7 +141,7 @@
             <select name="ingredients" id="ingredient-drop-down-menu" class="selectMenu">
             </select>
             <form class="quantity">
-              <input type="text" placeholder="quantity" class="quantityInput" id="quantity-input">
+              <input type="number" placeholder="quantity" class="quantityInput" id="quantity-input">
             </form>
             <button type="button" class="addButton" id="add-button" disabled>Add to Pantry</button>
         </menu>

--- a/dist/index.html
+++ b/dist/index.html
@@ -25,7 +25,7 @@
       <form class="filter-section" id="filterSection">
         <fieldset class="search">
             <input type="text" class="search-field" placeholder="Search..." id="search-bar">
-          <button type="button" class="submit-search-button" id="submit-search-button">Search</button>
+          <button type="button" class="submit-search-button" id="submit-search-button" disabled>Search</button>
         </fieldset>
         <datalist class = "tags" id="tags">
           <menu class="category-and-reset-container">

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -75,13 +75,12 @@ addButton.addEventListener('click', () => {
 cookRecipeButton.addEventListener('click', cookRecipe)
 pantryInputs.forEach(input => {
     input.addEventListener('input', () => {
-        console.log(inputQuantity.value, selectIngredient.value)
         if(inputQuantity.value !== '' && selectIngredient.value !== 'Choose Ingredient') {
             addButton.disabled = false
-        }else {
+        } else {
             addButton.disabled = true
         }
-    }) 
+    })
 })
 inputQuantity.addEventListener('keypress', (event) => {
     if(event.key === "Enter"){
@@ -92,10 +91,10 @@ inputQuantity.addEventListener('keypress', (event) => {
 searchBar.addEventListener('input', () => {
     if(searchBar.value !== '') {
         submitButton.disabled = false
-    }else {
+    } else {
         submitButton.disabled = true
     }
-}) 
+})
 searchBar.addEventListener('keypress', (event) => {
     if (event.key === 'Enter' && homeView) {
         event.preventDefault()
@@ -206,7 +205,7 @@ function giveCookingFeedback() {
         displayMissingIngr()
         hide([cookRecipeButton, favoriteRecipeButton])
         show([cookStatusSection, ingredientsNeededToCook, removeRecipeButton, favoriteButton])
-    } 
+    }
     else if(user.pantry.userCanCook) {
         show([cookRecipeButton, favoriteButton])
         hide([ingredientsNeededToCook, cookStatusSection, favoriteRecipeButton])
@@ -541,4 +540,3 @@ function cookRecipe() {
     }, 4000)
     user.removeRecipesToCook(foundRecipe)
 }
-

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -76,6 +76,13 @@ inputQuantity.addEventListener('keypress', (event) => {
         addItemToPantry()
     }
 })
+searchBar.addEventListener('input', () => {
+    if(!searchBar.value === '') {
+        submitButton.disabled = true
+    }else {
+        submitButton.disabled = false
+    }
+}) 
 searchBar.addEventListener('keypress', (event) => {
     if (event.key === 'Enter' && homeView) {
         event.preventDefault()
@@ -87,8 +94,10 @@ searchBar.addEventListener('keypress', (event) => {
 })
 submitButton.addEventListener('click', () => {
     if (homeView) {
+        submitButton.disabled = true
         searchHomeRecipeByName()
     } else {
+        submitButton.disabled = true
         searchFavoriteRecipeByName()
     }
 })

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -68,8 +68,18 @@ favoriteRecipeButton.addEventListener('click', addRecipeToFavorites)
 removeRecipeButton.addEventListener('click', removeRecipeFromFavorites)
 favoriteButton.addEventListener('click', displayFavoritesPage)
 pantryButton.addEventListener('click', displayPantryPage)
-addButton.addEventListener('click', addItemToPantry)
+addButton.addEventListener('click', () => {
+    addButton.disabled = true
+    addItemToPantry()
+})
 cookRecipeButton.addEventListener('click', cookRecipe)
+inputQuantity.addEventListener('input', () => {
+    if(!inputQuantity.value === '') {
+        addButton.disabled = true
+    }else {
+        addButton.disabled = false
+    }
+}) 
 inputQuantity.addEventListener('keypress', (event) => {
     if(event.key === "Enter"){
         event.preventDefault();

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -20,7 +20,6 @@ let apiIngredients
 let postItNote
 let foundIt
 let recipeView = false
-
 const usersURL = 'http://localhost:3001/api/v1/users'
 const recipesURL = 'http://localhost:3001/api/v1/recipes'
 const ingredientsURL = 'http://localhost:3001/api/v1/ingredients'
@@ -49,6 +48,7 @@ const pantryTable = document.querySelector('#pantry-table')
 const navMessage = document.querySelector('.current-view-message')
 const addButton = document.querySelector('#add-button')
 const inputQuantity = document.querySelector('#quantity-input')
+let pantryInputs = [inputQuantity, selectIngredient]
 const cookRecipeButton = document.querySelector('#cook-recipe-button')
 const errorMessage = document.querySelector('#error-handling')
 const cookStatusSection = document.querySelector('#can-cook-section')
@@ -73,13 +73,16 @@ addButton.addEventListener('click', () => {
     addItemToPantry()
 })
 cookRecipeButton.addEventListener('click', cookRecipe)
-inputQuantity.addEventListener('input', () => {
-    if(!inputQuantity.value === '') {
-        addButton.disabled = true
-    }else {
-        addButton.disabled = false
-    }
-}) 
+pantryInputs.forEach(input => {
+    input.addEventListener('input', () => {
+        console.log(inputQuantity.value, selectIngredient.value)
+        if(inputQuantity.value !== '' && selectIngredient.value !== 'Choose Ingredient') {
+            addButton.disabled = false
+        }else {
+            addButton.disabled = true
+        }
+    }) 
+})
 inputQuantity.addEventListener('keypress', (event) => {
     if(event.key === "Enter"){
         event.preventDefault();
@@ -87,10 +90,10 @@ inputQuantity.addEventListener('keypress', (event) => {
     }
 })
 searchBar.addEventListener('input', () => {
-    if(!searchBar.value === '') {
-        submitButton.disabled = true
-    }else {
+    if(searchBar.value !== '') {
         submitButton.disabled = false
+    }else {
+        submitButton.disabled = true
     }
 }) 
 searchBar.addEventListener('keypress', (event) => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -21,6 +21,10 @@ button {
   border-radius: 10px;
 }
 
+:disabled {
+  background:rgba(169, 110, 110, 0.7)
+ }
+
 button,
 .food-category,
 .fullcap {

--- a/src/styles.css
+++ b/src/styles.css
@@ -276,17 +276,21 @@ select {
   width: 24vw;
 }
 
-div {
+.required-message {
   display: flex;
-  width: 38vw;
-  justify-content:flex-end
+  width: 45vw;
+  justify-content:space-evenly;
+  margin-left: 15vw;
 }
 
-span {
-  font-size: 1em;
-  color:#974343;
-  margin-left: 8vw;
+.message {
+  margin-top: 0px;
+  font-size: 0.8em;
 } 
+
+span {
+  color:#974343;
+}
 
 .quantity {
   display: flex;


### PR DESCRIPTION
Summary of the work done:
Complete error handling prevention by: 
- Require number input type for quantity field on pantry page
- Disable "add to pantry" button until a drop down item is selected AND a numerical value is in quantity field
- Disable "submit" button for search bar if the search bar is empty
- Modified HTML element tags for the message to users on pantry class to be more semantic. Now, the span only appears on the asterisk AND there are no divs

Contributed to code:
Jenn

Needs to review:
Lauren and Eleanor

Additional notes about any issues/questions remaining around this code:

- I'd love for you to pull this down and test it out in case I have missed anything. 
